### PR TITLE
Updates to support use of CSI Drivers, OIDC flows and proxy header tweaks

### DIFF
--- a/backend/app/entrypoint.sh
+++ b/backend/app/entrypoint.sh
@@ -151,13 +151,29 @@ http {
       alias /etc/localcoda/www/favicon.ico;
     }
   }
+  # Extract port from Host header if present
+  map \$http_host \$forwarded_port {
+      # Host includes a port - extract it
+      ~^(?<h>[^:]+):(?<p>\d+)$  \$p;
+      # No port - choose default based on scheme
+      default \$scheme_default_port;
+  }
+  # Determine default port based on scheme
+  map \$scheme \$scheme_default_port {
+      http   80;
+      https  443;
+  }
   server {
     listen $EXT_LISTENPORT;
     server_name $EXT_PROXYHOST_REGEX;
     location / {
       proxy_pass http://127.0.0.1:\$redport;
+      proxy_set_header Host \$http_host;
+      proxy_set_header X-Forwarded-Host \$http_host;
       proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto \$scheme;
+      proxy_set_header X-Forwarded-Port \$forwarded_port;
+      proxy_http_version 1.1;
       proxy_set_header Upgrade \$http_upgrade;
       proxy_set_header Connection \$connection_upgrade;
       proxy_redirect off;

--- a/backend/app/entrypoint.sh
+++ b/backend/app/entrypoint.sh
@@ -102,6 +102,11 @@ http {
   perl_modules /etc/localcoda;
   perl_require nginx-cmd.pm;
 
+  # Large buffer sizes for handling large headers (e.g., auth tokens, OIDC flows etc.)
+  proxy_buffer_size          32k;
+  proxy_buffers              8 32k;
+  proxy_busy_buffers_size    64k;
+  large_client_header_buffers 4 32k;
 
   map \$http_upgrade \$connection_upgrade {
     default upgrade;

--- a/backend/bin/backend_run.sh
+++ b/backend/bin/backend_run.sh
@@ -266,7 +266,7 @@ if [[ $ORCHESTRATION_ENGINE == "local" ]]; then
 
   # Volume mounts requiring shared bind mount propagation - e.g. for CSI drivers
   eval KUBELET_LOCAL_BIND_MOUNT=${LOCAL_BIND_MOUNT_ROOT}/kubelet
-  mkdir -p "${KUBELET_LOCAL_BIND_MOUNT}"  # eval zzz
+  mkdir -p "${KUBELET_LOCAL_BIND_MOUNT}"
   DOCKER_RUN_ARGS="$DOCKER_RUN_ARGS --mount type=bind,source=${KUBELET_LOCAL_BIND_MOUNT},target=/var/lib/kubelet,bind-propagation=rshared"
 
   #Get runtime engine

--- a/backend/bin/backend_run.sh
+++ b/backend/bin/backend_run.sh
@@ -264,6 +264,11 @@ if [[ $ORCHESTRATION_ENGINE == "local" ]]; then
 	fi
   [[ "$BACKEND_T_MODE" == "rw" ]] || DOCKER_RUN_ARGS="$DOCKER_RUN_ARGS,ro"
 
+  # Volume mounts requiring shared bind mount propagation - e.g. for CSI drivers
+  eval KUBELET_LOCAL_BIND_MOUNT=${LOCAL_BIND_MOUNT_ROOT}/kubelet
+  mkdir -p "${KUBELET_LOCAL_BIND_MOUNT}"  # eval zzz
+  DOCKER_RUN_ARGS="$DOCKER_RUN_ARGS --mount type=bind,source=${KUBELET_LOCAL_BIND_MOUNT},target=/var/lib/kubelet,bind-propagation=rshared"
+
   #Get runtime engine
   if [[ $VIRT_ENGINE == "docker" ]]; then
     DOCKER_RUN_ARGS="$DOCKER_RUN_ARGS --privileged --cgroupns=host"

--- a/backend/cfg/conf
+++ b/backend/cfg/conf
@@ -27,6 +27,8 @@ EXT_BK_MAINHOST_SCHEME="\$LOCAL_UUID-lc\$EXT_DOMAIN_NAME"
 EXT_BK_PROXYHOST_SCHEME="\$PORT-\$LOCAL_UUID-lc\$EXT_DOMAIN_NAME"
 #Backend orchestration execution identifier shcheme (you should never change this, unless you know what you are doing)
 EXECUTION_NAME_SCHEME="lc-bk-\$LOCAL_UUID"
+#Root directory for local volume bind mounts
+LOCAL_BIND_MOUNT_ROOT="\${HOME}/localcoda/\${LOCAL_UUID}"
 #Tutorials volume/pvc name. If this is a PVC, it is created with ReadWriteMany (you should never change this, unless you know what you are doing)
 TUTORIALS_VOLUME="lc-tutorials"
 #Local mount of the tutorials volume. If set, backend will check the volume againist this path, avoiding accessing the volume via specific containers. Note that, if running the backend via the frontend, this parameter is ignored and always set to /data/tutorial , which is the hardocded mount path in the frontend (you should never change this, unless you know what you are doing)

--- a/backend/cfg/imagemap.sysbox
+++ b/backend/cfg/imagemap.sysbox
@@ -1,4 +1,4 @@
-#Use the format <image-ID-in-tutorial> <image-name-plus-tag> <image-hostname> (spaces are not allowed in any of hte entries)
+#Use the format <image-ID-in-tutorial> <image-name-plus-tag> <image-hostname> <memory limit> <cpu limit> (spaces are not allowed in any of the entries)
 ubuntu spinto/localcoda-sysbox-ubuntu:latest ubuntu 0 0
 ubuntu-4GB spinto/localcoda-sysbox-ubuntu:latest ubuntu 0 0
 kubernetes-kubeadm-1node spinto/localcoda-sysbox-k3s:latest controlplane 0 0

--- a/backend/cfg/imagemap.sysbox
+++ b/backend/cfg/imagemap.sysbox
@@ -1,5 +1,5 @@
 #Use the format <image-ID-in-tutorial> <image-name-plus-tag> <image-hostname> (spaces are not allowed in any of hte entries)
-ubuntu spinto/localcoda-sysbox-ubuntu:latest ubuntu
-ubuntu-4GB spinto/localcoda-sysbox-ubuntu:latest ubuntu
-kubernetes-kubeadm-1node spinto/localcoda-sysbox-k3s:latest controlplane
-kubernetes-kubeadm-1node-4GB spinto/localcoda-sysbox-k3s:latest controlplane
+ubuntu spinto/localcoda-sysbox-ubuntu:latest ubuntu 0 0
+ubuntu-4GB spinto/localcoda-sysbox-ubuntu:latest ubuntu 0 0
+kubernetes-kubeadm-1node spinto/localcoda-sysbox-k3s:latest controlplane 0 0
+kubernetes-kubeadm-1node-4GB spinto/localcoda-sysbox-k3s:latest controlplane 0 0

--- a/docs/DEPLOY_LOCAL.md
+++ b/docs/DEPLOY_LOCAL.md
@@ -49,8 +49,11 @@ If you do not want to do that, you can manually setup a reverse proxy on front o
     server_name ~-(?<redport>[0-9]+)\\.$EXT_DOMAIN_NAME\$;
     location / {
       proxy_pass http://127.0.0.1:\$redport;
+      proxy_set_header Host \$http_host;
+      proxy_set_header X-Forwarded-Host \$http_host;
       proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto \$scheme;
+      proxy_http_version 1.1;
       proxy_set_header Upgrade \$http_upgrade;
       proxy_set_header Connection \$connection_upgrade;
       proxy_set_header Host \$host;


### PR DESCRIPTION
* **CSI Driver support**
  CSI drivers (such as `csi-rclone`) require access to the node `/var/lib/kubelet` directory with shared bind mount propagation
* **OIDC flows**
  Require nginx mods (increase buffer sizes) to allow for large headers - such as callbacks redirects with tokens etc. Otherwise nginx fails to proxy these responses and instead returns `502` error responses
* **Proxy Headers**
  Setting of additional proxy headers for the benefit of proxied services to know their external URL